### PR TITLE
Some fixes

### DIFF
--- a/library/sshknownhosts
+++ b/library/sshknownhosts
@@ -107,9 +107,9 @@ def read_known_hosts(dest):
 # locate a host in the known hosts array.
 # return the position if found, or -1 if not found
 def find_host(lines, host, port, enctype=None):
-    
-    enc_lookup=dict(dsa='ssh-dss', rsa='ssh-rsa', ecdsa='ecdsa-sha2-nistp256')
-    
+
+    enc_lookup=dict(dsa='ssh-dss', rsa='ssh-rsa', ecdsa='ecdsa-sha2-nistp256', ed25519='ssh-ed25519')
+
     if port == "22":
         # if enctype is not defined search for any possible encryption type
         if enctype:
@@ -132,7 +132,7 @@ def find_host(lines, host, port, enctype=None):
             mre = re.compile("^\[{0}\]\:{1}[ ,]+.*? {2} ".format(host, port, enc_lookup[enctype]))
         else:
             mre = re.compile("^\[{0}\]\:{1}[ ,]+.*? (({2})) ".format(host, port, ')|('.join(enc_lookup.values())))
-    
+
     found = -1
     for lineno, cur_line in enumerate(lines):
         if mre.search(cur_line):
@@ -207,7 +207,7 @@ def absent(module, dest, host, port):
     msg = ""
     lines = read_known_hosts(dest)
     found = find_host(lines, host, port)
-    
+
     if found != -1:
         del lines[found]
         write_known_hosts(module, dest, lines)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,4 +9,4 @@
     enctype: "{{ item.enctype|default(ssh_known_hosts_enctype) }}"
     port: "{{ item.port|default(ssh_known_hosts_port) }}"
     keyscan: "{{ item.keyscan|default(ssh_known_hosts_keyscan) }}"
-  with_items: ssh_known_hosts
+  with_items: "{{ ssh_known_hosts }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Manage ssh_known_hosts file
   sshknownhosts:
     host: "{{ item.name }}"
-    aliases: "{{ item.aliases|join(',') }}"
+    aliases: "{{ item.aliases|join(',') if item.aliases is defined else omit }}"
     state: "{{ item.state|default(ssh_known_hosts_state) }}"
     dest: "{{ item.path|default(ssh_known_hosts_path) }}"
     enctype: "{{ item.enctype|default(ssh_known_hosts_enctype) }}"


### PR DESCRIPTION
Added 'ed25519' again, because it got lost while merging.
Omit 'aliases' when it is not specified.
With ansible 2.0 the bare variables became deprecated.