### PR TITLE
Allow to pin ssh fingerprints

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,9 @@ ssh_known_hosts_keyscan: ssh-keyscan
 #      - www2.example.com
 
 ssh_known_hosts: []
+
+ssh_known_hosts_enctype_lookup:
+  dsa: ssh-dss
+  rsa: ssh-rsa
+  ecdsa: ecdsa-sha2-nistp256
+  ed25519: ssh-ed25519

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,3 +10,12 @@
     port: "{{ item.port|default(ssh_known_hosts_port) }}"
     keyscan: "{{ item.keyscan|default(ssh_known_hosts_keyscan) }}"
   with_items: "{{ ssh_known_hosts }}"
+  when: "{{ item.fingerprint is undefined }}"
+
+- name: Add lines for specified fingerprints
+  lineinfile: 
+    dest: "{{ item.path|default(ssh_known_hosts_path) }}"
+    regexp: "^{{ item.name }}"
+    line: "{{ ([ item.name ] + item.aliases)|join(',') if item.aliases is defined else item.name }} {{ ssh_known_hosts_enctype_lookup[item.enctype|default(ssh_known_hosts_enctype)] }} {{ item.fingerprint }}"
+  with_items: "{{ ssh_known_hosts }}"
+  when: "{{ item.fingerprint is defined }}"


### PR DESCRIPTION
Assemble line in known_hosts file manually,
if fingerprint is defined

fixes #6 