### PR TITLE
Add ability to add all hosts from inventory to ssh_known_hosts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,8 +5,11 @@ ssh_known_hosts_state: present
 ssh_known_hosts_enctype: rsa
 ssh_known_hosts_port: 22
 ssh_known_hosts_keyscan: ssh-keyscan
-# import all hosts from inventory to ssh_known_hosts
+
+# add all host from inventory to ssh_known_host
 ssh_known_hosts_use_inventory: False
+# if adding from inventory, add shortname as alias
+ssh_known_hosts_use_shortnames: False
 
 #ssh_known_hosts:
 #  - name: example.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,8 @@ ssh_known_hosts_state: present
 ssh_known_hosts_enctype: rsa
 ssh_known_hosts_port: 22
 ssh_known_hosts_keyscan: ssh-keyscan
+# import all hosts from inventory to ssh_known_hosts
+ssh_known_hosts_use_inventory: False
 
 #ssh_known_hosts:
 #  - name: example.com

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,12 @@
 ---
 # Where the rubber meets the road. stuff gets done
+
+- name: Add all hosts from inventory to ssh_known_hosts
+  set_fact:
+    ssh_known_hosts: "{{ ssh_known_hosts + [{ 'name': item }] }}"
+  with_items: groups['all']
+  when: ssh_known_hosts_use_inventory and item not in ssh_known_hosts
+
 - name: Manage ssh_known_hosts file
   sshknownhosts:
     host: "{{ item.name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,8 +4,21 @@
 - name: Add all hosts from inventory to ssh_known_hosts
   set_fact:
     ssh_known_hosts: "{{ ssh_known_hosts + [{ 'name': item }] }}"
-  with_items: groups['all']
-  when: ssh_known_hosts_use_inventory and item not in ssh_known_hosts
+  with_items: "{{ groups['all'] }}"
+  when: ssh_known_hosts_use_inventory and
+          not ssh_known_hosts_use_shortnames and
+          item not in ssh_known_hosts|map(attribute='name')
+  run_once: true
+ 
+- name: Add all hosts from inventory to ssh_known_hosts with shortname alias
+  set_fact:
+    ssh_known_hosts: "{{ ssh_known_hosts + [{ 'name': item,
+                      'aliases': [item.split('.')[0]] }] }}"
+  with_items: "{{ groups['all'] }}"
+  when: ssh_known_hosts_use_inventory and
+          ssh_known_hosts_use_shortnames and
+          item not in ssh_known_hosts|map(attribute='name')
+  run_once: true
 
 - name: Manage ssh_known_hosts file
   sshknownhosts:


### PR DESCRIPTION
Deactivated by default. Current behavior is not changed.

Added ability to additionally add the hosts shortname as alias.